### PR TITLE
Allow configuring deployment parameters

### DIFF
--- a/stable/kube-ingress-aws-controller/templates/daemonset.yaml
+++ b/stable/kube-ingress-aws-controller/templates/daemonset.yaml
@@ -31,13 +31,13 @@ spec:
         imagePullPolicy: "{{ .Values.daemonset.image.pullPolicy }}"
         ports:
         - name: ingress-port
-          containerPort: 9999
-          hostPort: 9999
+          containerPort: {{ .Values.daemonset.port }}
+          hostPort: {{ .Values.daemonset.port }}
         args:
           - "skipper"
           - "-kubernetes"
           - "-kubernetes-in-cluster"
-          - "-address=:9999"
+          - "-address=:{{ .Values.daemonset.port }}"
           - "-proxy-preserve-host"
           - "-serve-host-metrics"
           - "-enable-ratelimits"

--- a/stable/kube-ingress-aws-controller/templates/deployment.yaml
+++ b/stable/kube-ingress-aws-controller/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ template "kube-ingress-aws-controller.name" . }}
         release: {{ .Release.Name }}
         component: ingress
+{{- if .Values.controller.annotations }}
+      annotations:
+{{ toYaml .Values.controller.annotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "kube-ingress-aws-controller.serviceAccountName" . }}
       containers:
@@ -30,3 +34,17 @@ spec:
         env:
         - name: AWS_REGION
           value: {{ .Values.controller.awsRegion }}
+        resources:
+{{ toYaml .Values.controller.resources | indent 10 }}
+    {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/kube-ingress-aws-controller/values.yaml
+++ b/stable/kube-ingress-aws-controller/values.yaml
@@ -1,11 +1,18 @@
 controller:
   ## AWS region in which this ingress controller will operate
   awsRegion: us-west-1
+
   ## Container image used for the Ingress Controller
   image:
     repository: registry.opensource.zalan.do/teapot/kube-ingress-aws-controller
     tag: "v0.6.8"
     pullPolicy: IfNotPresent
+
+  annotations: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 daemonset:
   ## Container image used for the Daemon set
@@ -13,6 +20,10 @@ daemonset:
     repository: registry.opensource.zalan.do/pathfinder/skipper
     tag: "v0.9.202"
     pullPolicy: IfNotPresent
+
+  ## Port to open on the host and listen for connections on
+  port: 9999
+
   # Resource configuration for limits and requests
   resources: {}
     # limits:


### PR DESCRIPTION
Allow adding annotations, resource limits, affinity and other parameters
and parametize the port used.

I need this specifically to add an annotation for kube2iam but in general giving people this flexibility is appreciated. 